### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
-  #  before_action :set_item, only: [:edit, :update]
-  #  before_action :redirect_unless_author, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create,:edit, :update]
+  before_action :set_item, only: [:edit, :update]
+  before_action :redirect_unless_author, only: [:edit, :update]
 
 
   def index
@@ -30,13 +30,14 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     end
     
-   # def update 
-   #  if @item.update(item_params)
-   #    redirect_to item_path(@item)
-   #   else
-   #   render :edit 
-   #   end
-   # end
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,6 +27,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item = Item.find(params[:id])
     end
     
    # def update 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create,:edit, :update]
-  before_action :set_item, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :redirect_unless_author, only: [:edit, :update]
 
 
@@ -13,7 +13,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
+
   end
 
   def create
@@ -27,11 +27,9 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
-    end
+  end
     
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item)
     else

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url: items_path, local: true do |f| %>
-
-
-   <%= render 'shared/error_messages', model: f.object %>
+    <%= form_with model: @item,local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -140,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる',item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root 'items#index'
-  resources :items, only: [:new, :create, :index,:show,:edit, :update]
+  resources :items, only: [:new,:create,:index,:show,:edit,:update]
   # Defines the root path route ("/")
   # root "articles#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root 'items#index'
-  resources :items, only: [:new, :create, :index,:show]
+  resources :items, only: [:new, :create, :index,:show,:edit, :update]
   # Defines the root path route ("/")
   # root "articles#index"
 end


### PR DESCRIPTION
#What
商品情報編集機能の実装
#Why
商品情報を編集可能にするため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/e8a3c0929caa57530ecd02e9c7d84783
 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/da4027773bfbad1aff50587b22044219
https://gyazo.com/948141f7ee0c77c7893c76b99de1fd70
入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/03cfd788af9ac11b5895502087785fae
何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/8a850aadc7eda68796cca1f7bdb7ddfa
ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/3a21a8f39cc28ea488402d601ebcfa1f
ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/42609ebfb990ac808dcf76b81643b8cc
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/6ac96be84a511c9279e1aa55bbb7aac6